### PR TITLE
Enable Reproducible Builds via goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,18 @@ builds:
       - amd64
       - arm
       - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.CommitDate}}
+      - -X main.builtBy=goreleaser
+      - -X github.com/reconmap/cli/internal/build.BuildVersion={{.Version}}
+      - -X github.com/reconmap/cli/internal/build.BuildTime={{.CommitDate}}
+      - -X github.com/reconmap/cli/internal/build.BuildCommit={{.Commit}}
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+    - -trimpath
 
 brews:
   - name: rmap
@@ -42,6 +54,9 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+    format_overrides:
+    - goos: windows
+      format: zip
 
 checksum:
   name_template: "checksums.txt"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := bash
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 LATEST_TAG = $(shell git describe --tags)
+GORELEASER := goreleaser
 
 PROGRAM=rmap
 
@@ -19,3 +20,6 @@ tests:
 clean:
 	rm -f $(PROGRAM)
 
+.PHONY: snapshot
+snapshot:
+	$(GORELEASER) --snapshot --skip-publish --rm-dist

--- a/cmd/rmap/main.go
+++ b/cmd/rmap/main.go
@@ -16,6 +16,10 @@ func main() {
 	logger := logging.GetLoggerInstance()
 	defer logger.Sync()
 
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("Version=%s\nBuildDate=%s\nGitCommit=%s\n", c.App.Version, build.BuildTime, build.BuildCommit)
+	}
+
 	app := cli.NewApp()
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{

--- a/internal/build/info.go
+++ b/internal/build/info.go
@@ -1,5 +1,7 @@
 package build
 
-var BuildTime string
-var BuildVersion string
-var BuildCommit string
+var (
+	BuildTime    string
+	BuildVersion string
+	BuildCommit  string
+)

--- a/internal/build/info.go
+++ b/internal/build/info.go
@@ -2,3 +2,4 @@ package build
 
 var BuildTime string
 var BuildVersion string
+var BuildCommit string


### PR DESCRIPTION
- [X] Configure GoReleaser for [reproducible builds](https://goreleaser.com/customization/build/\#reproducible-builds)
- [X] Set build information for --version flag
- [X] Set .zip for windows files


```shell
make snapshot

./rmap --version                
Version=0.9.13-next
BuildDate=2021-10-03T01:57:35Z
GitCommit=721af5272b209776bffcbae04a0edff9f8427890
```

![image](https://user-images.githubusercontent.com/8380706/135736840-84b1d120-ae50-4b95-9cec-f8da90c318d8.png)
