### PR TITLE
Generate spdx software bill of materials

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,11 +22,13 @@ jobs:
           go-version: 1.17
         id: go
 
-      - name:  Generate Software Bill of Materials
-        uses:  docker://spdx/spdx-sbom-generator
-        with:
-          args:
-            --path /github/workspace/
+      - name: Generate sbom
+        run: |
+          wget -qO- "https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz" | \
+          tar xvz && \
+          chmod +x spdx-sbom-generator
+          ./spdx-sbom-generator --path .
+        shell: bash
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.7.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -22,6 +22,12 @@ jobs:
           go-version: 1.17
         id: go
 
+      - name:  Generate Software Bill of Materials
+        uses:  docker://spdx/spdx-sbom-generator
+        with:
+          args:
+            --path /github/workspace/
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.7.0
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,7 +36,6 @@ jobs:
         tar xvz && \
         chmod +x spdx-sbom-generator
         ./spdx-sbom-generator --path .
-
       shell: bash
 
     - name: Create Snapshot

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,6 +32,9 @@ jobs:
 
     - name:  Generate Software Bill of Materials
       uses:  docker://spdx/spdx-sbom-generator
+      with:
+        args:
+          --path .
 
     - name: Create Snapshot
       uses: goreleaser/goreleaser-action@v2.7.0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,8 +36,7 @@ jobs:
         ar xvz --wildcards --directory='/usr/bin/' --strip-components=1 '*/spdx-sbom-generator'  && \
         chmod +x /usr/bin/spdx-sbom-generator
       shell: bash
-
-  Validate:
+      
     - name: Create Snapshot
       uses: goreleaser/goreleaser-action@v2.7.0
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,10 +33,10 @@ jobs:
     - name: Generate sbom
       run: |
         wget -qO- "https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz" | \
-        ar xvz --wildcards --directory='/usr/bin/' --strip-components=1 '*/spdx-sbom-generator'  && \
+        tar xvz --wildcards --directory='/usr/bin/' --strip-components=1 '*/spdx-sbom-generator'  && \
         chmod +x /usr/bin/spdx-sbom-generator
       shell: bash
-      
+
     - name: Create Snapshot
       uses: goreleaser/goreleaser-action@v2.7.0
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Generate sbom
       run: |
         wget -qO- "https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz" | \
-        tar xvz --wildcards --directory='/usr/bin/' --strip-components=1 '*/spdx-sbom-generator'  && \
+        tar xvz --directory='/usr/bin/' && \
         chmod +x /usr/bin/spdx-sbom-generator
       shell: bash
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,9 @@ jobs:
 
     - name: Test
       run: go test -v ./...
-
+  validate:
+    runs-on: ubuntu-latest
+    steps:
     - name:  Generate Software Bill of Materials
       uses:  docker://spdx/spdx-sbom-generator
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -32,9 +32,6 @@ jobs:
 
     - name:  Generate Software Bill of Materials
       uses:  docker://spdx/spdx-sbom-generator
-      with:
-        args:
-          --path /github/workspace/
 
     - name: Create Snapshot
       uses: goreleaser/goreleaser-action@v2.7.0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,15 +29,15 @@ jobs:
 
     - name: Test
       run: go test -v ./...
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-    - name:  Generate Software Bill of Materials
-      uses:  docker://spdx/spdx-sbom-generator
-      with:
-        args:
-          --path .
 
+    - name: Generate sbom
+      run: |
+        wget -qO- "https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz" | \
+        ar xvz --wildcards --directory='/usr/bin/' --strip-components=1 '*/spdx-sbom-generator'  && \
+        chmod +x /usr/bin/spdx-sbom-generator
+      shell: bash
+
+  Validate:
     - name: Create Snapshot
       uses: goreleaser/goreleaser-action@v2.7.0
       with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,6 +35,8 @@ jobs:
         wget -qO- "https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz" | \
         tar xvz && \
         chmod +x spdx-sbom-generator
+        spdx-sbom-generator --path .
+
       shell: bash
 
     - name: Create Snapshot

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,3 +29,15 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name:  Generate Software Bill of Materials
+      uses:  docker://spdx/spdx-sbom-generator
+      with:
+        args:
+          --path /github/workspace/
+
+    - name: Create Snapshot
+      uses: goreleaser/goreleaser-action@v2.7.0
+      with:
+        version: latest
+        args: --snapshot --skip-publish --rm-dist

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -35,7 +35,7 @@ jobs:
         wget -qO- "https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz" | \
         tar xvz && \
         chmod +x spdx-sbom-generator
-        spdx-sbom-generator --path .
+        ./spdx-sbom-generator --path .
 
       shell: bash
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Generate sbom
       run: |
         wget -qO- "https://github.com/spdx/spdx-sbom-generator/releases/download/v0.0.13/spdx-sbom-generator-v0.0.13-linux-amd64.tar.gz" | \
-        tar xvz --directory='/usr/bin/' && \
-        chmod +x /usr/bin/spdx-sbom-generator
+        tar xvz && \
+        chmod +x spdx-sbom-generator
       shell: bash
 
     - name: Create Snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ rmap-session
 *.xml
 *.log
 tags
+bom-go-mod.spdx

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,6 +31,10 @@ builds:
     flags:
     - -trimpath
 
+release:
+  extra_files:
+    - glob: bom-go-mod.spdx
+
 brews:
   - name: rmap
     homepage: 'https://github.com/reconmap'

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ tests:
 clean:
 	rm -f $(PROGRAM)
 
+.PHONY: sbom
+sbom:
+	docker run -it --rm \
+    -v $(CURDIR):/reconmap/cli \
+    spdx/spdx-sbom-generator --path /reconmap/cli
+
 .PHONY: snapshot
-snapshot:
+snapshot: sbom
 	$(GORELEASER) --snapshot --skip-publish --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ clean:
 sbom:
 	docker run -it --rm \
     -v $(CURDIR):/reconmap/cli \
+	-w /reconmap/cli \
     spdx/spdx-sbom-generator --path /reconmap/cli
 
 .PHONY: snapshot

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,9 @@ clean:
 .PHONY: sbom
 sbom:
 	docker run -it --rm \
-    -v $(CURDIR):/reconmap/cli \
+	-v $(CURDIR):/reconmap/cli \
 	-w /reconmap/cli \
-    spdx/spdx-sbom-generator --path /reconmap/cli
+	spdx/spdx-sbom-generator --path /reconmap/cli
 
 .PHONY: snapshot
 snapshot: sbom


### PR DESCRIPTION
- [X] Generate [spdx sbom](https://www.linuxfoundation.org/press-release/spdx-becomes-internationally-recognized-standard-for-software-bill-of-materials/)
- [X] Set test action to generate sbom and snapshots
- [X] Set release action to generate sbom and tie it with goreleaser as an additional release artifact
 
The only part not tested is gorelease publishing this sbom artifact in this repo.

![image](https://user-images.githubusercontent.com/8380706/135756282-facfc71f-f60d-4290-969e-c1cf1bf22213.png)
